### PR TITLE
Discard master/slave jargon

### DIFF
--- a/KEXPFullParser.py
+++ b/KEXPFullParser.py
@@ -47,7 +47,7 @@ LOG SETUP COMPLETE
 
 # Connect to a database
 try:
-	db = MySQLdb.connect(host="lhakexpmaster.c1kvj0gfryqy.us-east-1.rds.amazonaws.com", port=3306, user="lha_kexp_proof", passwd="Statesman1997", db="lhaKEXPMaster")
+	db = MySQLdb.connect(host="lhakexpmain.c1kvj0gfryqy.us-east-1.rds.amazonaws.com", port=3306, user="lha_kexp_proof", passwd="Statesman1997", db="lhaKEXPMain")
 	cursor = db.cursor()
 	logging.info("Successfully connected to database")
 except:

--- a/KEXP_Gracenote.py
+++ b/KEXP_Gracenote.py
@@ -45,7 +45,7 @@ LOG SETUP COMPLETE
 
 # Connect to the KEXP source database
 try:
-	db = MySQLdb.connect(host="lhakexpmaster.c1kvj0gfryqy.us-east-1.rds.amazonaws.com", port=3306, user="lha_kexp_proof", passwd="Statesman1997", db="lhaKEXPMaster")
+	db = MySQLdb.connect(host="lhakexpmain.c1kvj0gfryqy.us-east-1.rds.amazonaws.com", port=3306, user="lha_kexp_proof", passwd="Statesman1997", db="lhaKEXPMain")
 	cursor = db.cursor()
 	logging.info("Successfully connected to database")
 except:


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.